### PR TITLE
book: 3.13.67 release notes (MCP database_tables fix #164)

### DIFF
--- a/book-1-python/chapters/36-releases.md
+++ b/book-1-python/chapters/36-releases.md
@@ -1,5 +1,9 @@
 # Chapter 35: Release Notes
 
+## v3.13.67 (2026-07-10) - The MCP table browser, locked down
+
+**The `database_tables` dev-tool now has a real behavioural test.** A sibling bug in the PHP framework (#164) fataled the same tool: it called a method that does not exist instead of listing tables, and the test never caught it because it only checked the tool was registered, never that it ran. This framework already listed tables correctly, but carried the same blind spot in its own tests. The new test invokes the real handler against a real SQLite database and asserts a table list comes back, so this class of drift is caught here too. Shipped across all four frameworks.
+
 ## v3.13.66 (2026-07-10) - A self-describing CLI, and generators that ship their tests
 
 The command line grew up. The `tina4` client no longer keeps its own copy of what

--- a/book-2-php/chapters/36-releases.md
+++ b/book-2-php/chapters/36-releases.md
@@ -1,5 +1,11 @@
 # Chapter 35: Release Notes
 
+## v3.13.67 (2026-07-10) - The MCP table browser lists your tables again
+
+**The `database_tables` dev-tool works again.** It called `getDatabase()`, a method the base `Database` does not carry, so every call fataled with "Call to undefined method" and returned an error instead of your table list. The tool now calls `getTables()`, the adapter contract that actually lists tables. Drive the dev MCP server from an AI client and "list the tables" answers correctly.
+
+The bug hid in plain sight because the test only checked that the tool was registered, never that it ran. The new test invokes the real handler against a real SQLite database and asserts a table list comes back, so a silent fatal cannot ship again. All four frameworks gained the same behavioural test; Python, Ruby, and Node already called the right method. Reported by skorteva (#164).
+
 ## v3.13.66 (2026-07-10) - A self-describing CLI, and generators that ship their tests
 
 The command line grew up. The `tina4` client no longer keeps its own copy of what

--- a/book-3-ruby/chapters/36-releases.md
+++ b/book-3-ruby/chapters/36-releases.md
@@ -1,5 +1,9 @@
 # Chapter 35: Release Notes
 
+## v3.13.67 (2026-07-10) - The MCP table browser, locked down
+
+**The `database_tables` dev-tool now has a real behavioural test.** A sibling bug in the PHP framework (#164) fataled the same tool: it called a method that does not exist instead of listing tables, and the test never caught it because it only checked the tool was registered, never that it ran. This framework already listed tables correctly, but carried the same blind spot in its own tests. The new test invokes the real handler against a real SQLite database and asserts a table list comes back, so this class of drift is caught here too. Shipped across all four frameworks.
+
 ## v3.13.66 (2026-07-10) - A self-describing CLI, and generators that ship their tests
 
 The command line grew up. The `tina4` client no longer keeps its own copy of what

--- a/book-4-nodejs/chapters/36-releases.md
+++ b/book-4-nodejs/chapters/36-releases.md
@@ -1,5 +1,9 @@
 # Chapter 35: Release Notes
 
+## v3.13.67 (2026-07-10) - The MCP table browser, locked down
+
+**The `database_tables` dev-tool now has a real behavioural test.** A sibling bug in the PHP framework (#164) fataled the same tool: it called a method that does not exist instead of listing tables, and the test never caught it because it only checked the tool was registered, never that it ran. This framework already listed tables correctly, but carried the same blind spot in its own tests. The new test invokes the real handler against a real SQLite database and asserts a table list comes back, so this class of drift is caught here too. Shipped across all four frameworks.
+
 ## v3.13.66 (2026-07-10) - A self-describing CLI, and generators that ship their tests
 
 The command line grew up. The `tina4` client no longer keeps its own copy of what


### PR DESCRIPTION
3.13.67 release notes across the 4 books, mirroring the documentation site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)