### PR TITLE
docs(release): 3.13.68 release notes

### DIFF
--- a/book-1-python/chapters/36-releases.md
+++ b/book-1-python/chapters/36-releases.md
@@ -1,5 +1,9 @@
 # Chapter 35: Release Notes
 
+## v3.13.68 (2026-07-10) - Parity release
+
+A version bump to keep all four frameworks on the same number. No functional changes to the Python package since 3.13.67; the accompanying change is a fix to the Tina4 maintainer AI skill so it links plan and source files by a path that resolves when clicked.
+
 ## v3.13.67 (2026-07-10) - The MCP table browser, locked down
 
 **The `database_tables` dev-tool now has a real behavioural test.** A sibling bug in the PHP framework (#164) fataled the same tool: it called a method that does not exist instead of listing tables, and the test never caught it because it only checked the tool was registered, never that it ran. This framework already listed tables correctly, but carried the same blind spot in its own tests. The new test invokes the real handler against a real SQLite database and asserts a table list comes back, so this class of drift is caught here too. Shipped across all four frameworks.

--- a/book-2-php/chapters/36-releases.md
+++ b/book-2-php/chapters/36-releases.md
@@ -1,5 +1,9 @@
 # Chapter 35: Release Notes
 
+## v3.13.68 (2026-07-10) - Firebird counts again
+
+`count()` and `recordExists()` return the right number on Firebird. Firebird folds an unquoted column alias to upper case, so `SELECT COUNT(*) as cnt` comes back under the key `CNT`. The ORM read a lower-case `cnt` that never existed and always returned 0, so every count looked empty and `recordExists()` always said no. Both now read the alias without caring about case. `insert()` also routes Firebird through `INSERT ... RETURNING` so a generated identity key lands back on the model, the same path Postgres already uses. Verified against a real Firebird 5.0.2 server. Reported in #132 (#133).
+
 ## v3.13.67 (2026-07-10) - The MCP table browser lists your tables again
 
 **The `database_tables` dev-tool works again.** It called `getDatabase()`, a method the base `Database` does not carry, so every call fataled with "Call to undefined method" and returned an error instead of your table list. The tool now calls `getTables()`, the adapter contract that actually lists tables. Drive the dev MCP server from an AI client and "list the tables" answers correctly.

--- a/book-3-ruby/chapters/36-releases.md
+++ b/book-3-ruby/chapters/36-releases.md
@@ -1,5 +1,9 @@
 # Chapter 35: Release Notes
 
+## v3.13.68 (2026-07-10) - Steadier test suite
+
+The documentation-search performance spec no longer fails at random. It timed a single request against a 50ms budget, and one slow sample on a busy machine turned the whole suite red. It now takes the best of several samples, so the check measures real speed instead of scheduler noise. Test-only; nothing in the framework changed.
+
 ## v3.13.67 (2026-07-10) - The MCP table browser, locked down
 
 **The `database_tables` dev-tool now has a real behavioural test.** A sibling bug in the PHP framework (#164) fataled the same tool: it called a method that does not exist instead of listing tables, and the test never caught it because it only checked the tool was registered, never that it ran. This framework already listed tables correctly, but carried the same blind spot in its own tests. The new test invokes the real handler against a real SQLite database and asserts a table list comes back, so this class of drift is caught here too. Shipped across all four frameworks.

--- a/book-4-nodejs/chapters/36-releases.md
+++ b/book-4-nodejs/chapters/36-releases.md
@@ -1,5 +1,9 @@
 # Chapter 35: Release Notes
 
+## v3.13.68 (2026-07-10) - Parity release
+
+A version bump to keep all four frameworks on the same number. No functional changes to the Node.js package since 3.13.67; the accompanying change is a fix to the Tina4 maintainer AI skill so it links plan and source files by a path that resolves when clicked.
+
 ## v3.13.67 (2026-07-10) - The MCP table browser, locked down
 
 **The `database_tables` dev-tool now has a real behavioural test.** A sibling bug in the PHP framework (#164) fataled the same tool: it called a method that does not exist instead of listing tables, and the test never caught it because it only checked the tool was registered, never that it ran. This framework already listed tables correctly, but carried the same blind spot in its own tests. The new test invokes the real handler against a real SQLite database and asserts a table list comes back, so this class of drift is caught here too. Shipped across all four frameworks.


### PR DESCRIPTION
3.13.68 release notes across the four framework books: PHP Firebird count()/recordExists() case-insensitive alias fix (#132/#133), Ruby docs-search perf-spec de-flake, Python/Node parity bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)